### PR TITLE
knife bootstrap windows winrm fails with Bad HTTP error

### DIFF
--- a/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
@@ -197,9 +197,11 @@ echo Validation key written.
 )
 <% end -%>
 
-<% unless trusted_certs_script.empty? -%>
-mkdir <%= bootstrap_directory %>\trusted_certs
-<%= trusted_certs_script %>
+<% if(Gem.loaded_specs["chef"].version.version.to_f >= 12) %>
+<% unless trusted_certs.empty? -%>
+mkdir -p C:/chef/trusted_certs
+<%= trusted_certs %>
+<% end -%>
 <% end -%>
 
 <%# Generate Ohai Hints -%>

--- a/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
@@ -197,9 +197,9 @@ echo Validation key written.
 )
 <% end -%>
 
-<% unless trusted_certs.empty? -%>
-mkdir -p C:/chef/trusted_certs
-<%= trusted_certs %>
+<% unless trusted_certs_script.empty? -%>
+mkdir <%= bootstrap_directory %>\trusted_certs
+<%= trusted_certs_script %>
 <% end -%>
 
 <%# Generate Ohai Hints -%>

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -122,8 +122,10 @@ CONFIG
             client_rb << %Q{encrypted_data_bag_secret "c:/chef/encrypted_data_bag_secret"\n}
           end
 
-          unless trusted_certs_script.empty?
-            client_rb << %Q{trusted_certs_dir "C:/chef/trusted_certs"\n}
+          if(Gem.loaded_specs["chef"].version.version.to_f >= 12)
+            unless trusted_certs.empty?
+              client_rb << %Q{trusted_certs_dir "c:/chef/trusted_certs"\n}
+            end
           end
 
           escape_and_echo(client_rb)

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -236,7 +236,7 @@ WGET_PS
         # This string should contain both the commands necessary to both create the files, as well as their content
         def trusted_certs_content
           content = ""
-          if @chef_config[:trusted_certs_dir] && (Gem.loaded_specs["chef"].version.version.to_f >= 12)
+          if @chef_config[:trusted_certs_dir]
             Dir.glob(File.join(Chef::Util::PathHelper.escape_glob(@chef_config[:trusted_certs_dir]), "*.{crt,pem}")).each do |cert|
               content << "cat > /C:/chef/trusted_certs/#{File.basename(cert)} <<'EOP'\n" +
                          IO.read(File.expand_path(cert)) + "\nEOP\n"

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -17,6 +17,7 @@
 #
 
 require 'chef/knife/core/bootstrap_context'
+require 'chef/util/path_helper'
 
 class Chef
   class Knife
@@ -250,7 +251,7 @@ WGET_PS
         end
 
         # FIXME: Remove this as well
-        def self.join(*args)
+        def join(*args)
           args.flatten.inject do |joined_path, component|
             # Joined path ends with /
             joined_path = joined_path.sub(/[#{Regexp.escape(File::SEPARATOR)}#{Regexp.escape(path_separator)}]+$/, '')
@@ -258,6 +259,15 @@ WGET_PS
             joined_path += "#{path_separator}#{component}"
           end
         end
+
+        def cleanpath(path)
+          path = Pathname.new(path).cleanpath.to_s
+          # ensure all forward slashes are backslashes
+          if Chef::Platform.windows?
+            path = path.gsub(File::SEPARATOR, path_separator)
+          end
+        path
+      end
 
         def fallback_install_task_command
           # This command will be executed by schtasks.exe in the batch

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -234,10 +234,10 @@ WGET_PS
         # This string should contain both the commands necessary to both create the files, as well as their content
         def trusted_certs_content
           content = ""
-          if @chef_config[:trusted_certs_dir]
-            Dir.glob(File.join(escape_glob(@chef_config[:trusted_certs_dir]), "*.{crt,pem}")).each do |cert|
-              content << "> #{bootstrap_directory}/trusted_certs/#{File.basename(cert)} (\n" +
-                         IO.read(File.expand_path(cert)) + "\n)\n"
+          if @chef_config[:trusted_certs_dir] && (Gem.loaded_specs["chef"].version.version.to_f >= 12)
+            Dir.glob(File.join(Chef::Util::PathHelper.escape_glob(@chef_config[:trusted_certs_dir]), "*.{crt,pem}")).each do |cert|
+              content << "cat > /C:/chef/trusted_certs/#{File.basename(cert)} <<'EOP'\n" +
+                         IO.read(File.expand_path(cert)) + "\nEOP\n"
             end
           end
           content

--- a/lib/chef/knife/winrm.rb
+++ b/lib/chef/knife/winrm.rb
@@ -43,6 +43,7 @@ class Chef
           Chef::Log.debug("Endpoint: #{endpoint}")
           Chef::Log.debug("Transport: #{options[:transport]}")
           @winrm_session = WinRM::WinRMWebService.new(endpoint, options[:transport], opts)
+          @winrm_session.set_timeout(options[:operation_timeout]) if options[:operation_timeout]
         end
 
         def relay_command(command)

--- a/spec/unit/knife/winrm_spec.rb
+++ b/spec/unit/knife/winrm_spec.rb
@@ -134,7 +134,7 @@ describe Chef::Knife::Winrm do
         let(:winrm_command_no_verify) { Chef::Knife::Winrm.new(['-m', 'localhost', '-x', 'testuser', '-P', 'testpassword', '--winrm-transport', 'ssl', '--winrm-ssl-verify-mode', 'verify_none', 'echo helloworld'])}
 
         it "should not validate the server when the ssl transport is used and the :winrm_ssl_verify_mode option is set to :verify_none" do
-          expect(winrm_command_no_verify.ui).to receive(:warn).exactly(2).times
+          expect(winrm_command_no_verify.ui).to receive(:warn).exactly(1).times
           expect(Chef::Knife::Winrm::Session).to receive(:new).with(hash_including(:transport => :ssl)).and_call_original
           expect(WinRM::WinRMWebService).to receive(:new).with(anything, anything, hash_including(:no_ssl_peer_verification => true)).and_return(@winrm_session)
           winrm_command_no_verify.configure_chef

--- a/spec/unit/knife/winrm_spec.rb
+++ b/spec/unit/knife/winrm_spec.rb
@@ -134,7 +134,7 @@ describe Chef::Knife::Winrm do
         let(:winrm_command_no_verify) { Chef::Knife::Winrm.new(['-m', 'localhost', '-x', 'testuser', '-P', 'testpassword', '--winrm-transport', 'ssl', '--winrm-ssl-verify-mode', 'verify_none', 'echo helloworld'])}
 
         it "should not validate the server when the ssl transport is used and the :winrm_ssl_verify_mode option is set to :verify_none" do
-          expect(winrm_command_no_verify.ui).to receive(:warn).exactly(1).times
+          expect(winrm_command_no_verify.ui).to receive(:warn).exactly(2).times
           expect(Chef::Knife::Winrm::Session).to receive(:new).with(hash_including(:transport => :ssl)).and_call_original
           expect(WinRM::WinRMWebService).to receive(:new).with(anything, anything, hash_including(:no_ssl_peer_verification => true)).and_return(@winrm_session)
           winrm_command_no_verify.configure_chef


### PR DESCRIPTION
chef-client gets installed on the node but node doesn't get registered on the hosted chef account.