### PR TITLE
Fixed download URL for Server 2003R2

### DIFF
--- a/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
@@ -71,7 +71,7 @@ goto architecture_select
 goto architecture_select
 
 :Version5.2
-@set MACHINE_OS=2003r2
+@set MACHINE_OS=2008r2
 goto architecture_select
 
 :Version6.1


### PR DESCRIPTION
Because the 2003R2 url no longer exists and uses 2008R2 link instead, we need to just point to the 2008R2 location.

Obvious fix.