### PR TITLE
Fixed bug related to chef gem version check

### DIFF
--- a/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/windows-chef-client-msi.erb
@@ -197,7 +197,7 @@ echo Validation key written.
 )
 <% end -%>
 
-<% if(Gem.loaded_specs["chef"].version.version.to_f >= 12) %>
+<% if(Gem::Specification.find_by_name('chef').version.version.to_f >= 12) %>
 <% unless trusted_certs.empty? -%>
 mkdir -p C:/chef/trusted_certs
 <%= trusted_certs %>

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -122,7 +122,7 @@ CONFIG
             client_rb << %Q{encrypted_data_bag_secret "c:/chef/encrypted_data_bag_secret"\n}
           end
 
-          if(Gem.loaded_specs["chef"].version.version.to_f >= 12)
+          if(Gem::Specification.find_by_name('chef').version.version.to_f >= 12)
             unless trusted_certs.empty?
               client_rb << %Q{trusted_certs_dir "c:/chef/trusted_certs"\n}
             end


### PR DESCRIPTION
```
DEBUG: Found bootstrap template in C:/opscode_live/chef/embedded/lib/ruby/gems/2.0.0/gems/knife-windows-1.0.0.dev.0/lib/chef/knife/bootstrap
ERROR: knife encountered an unexpected error
This may be a bug in the 'bootstrap windows winrm' knife command or plugin
Please collect the output of this command with the `-VV` option before filing a bug report.
Exception: NoMethodError: undefined method `version' for nil:NilClass
```

Implemented changes to fix above issue